### PR TITLE
add support for dashed attributes (e.g. data-role)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ rvm:
   - 1.9.3
   - 2.0.0
   - rbx
+  - jruby-18mode
   - jruby-19mode
 env:
 - COVERALLS=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ rvm:
   - 1.9.3
   - 2.0.0
   - rbx-18mode
-  - rbx-19mode
   - jruby-18mode
   - jruby-19mode
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: ruby
 rvm:
   - 1.9.3
   - 2.0.0
-  - rbx-18mode
+  - rbx
   - jruby-18mode
   - jruby-19mode
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ rvm:
   - 1.9.3
   - 2.0.0
   - rbx
-  - jruby-18mode
   - jruby-19mode
 env:
 - COVERALLS=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ rvm:
   - 1.9.3
   - 2.0.0
   - rbx
-  - jruby-19mode
+  - jruby
 env:
 - COVERALLS=true
 cache: bundler

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: ruby
 rvm:
-  - 1.8.7
   - 1.9.3
   - 2.0.0
   - rbx-18mode

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,4 @@ rvm:
   - jruby-19mode
 env:
 - COVERALLS=true
+cache: bundler

--- a/Gemfile
+++ b/Gemfile
@@ -9,3 +9,10 @@ group :test do
   gem "simplecov"
   gem 'coveralls', :require => false
 end
+
+
+platforms :rbx do
+  gem 'racc'
+  gem 'rubysl', '~> 2.0'
+  gem 'psych'
+end

--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,9 @@ end
 
 
 platforms :rbx do
-  gem 'racc'
+  gem 'racc'                     # if using gems like ruby_parser or parser
   gem 'rubysl', '~> 2.0'
   gem 'psych'
+  gem 'rubysl-test-unit'         # if using test-unit with minitest 5.x https://github.com/rubysl/rubysl-test-unit/issues/1
+  gem 'rubinius-developer_tools'
 end

--- a/lib/radius/parser/scanner.rb
+++ b/lib/radius/parser/scanner.rb
@@ -4,7 +4,7 @@ module Radius
     # The regular expression used to find (1) opening and self-enclosed tag names, (2) self-enclosing trailing slash, 
     # (3) attributes and (4) closing tag 
     def scanner_regex(prefix = nil)
-      %r{<#{prefix}:([-\w:]+?)(\s+(?:\w+\s*=\s*(?:"[^"]*?"|'[^']*?')\s*)*|)(\/?)>|<\/#{prefix}:([-\w:]+?)\s*>}
+      %r{<#{prefix}:([-\w:]+?)(\s+(?:[-\w]+\s*=\s*(?:"[^"]*?"|'[^']*?')\s*)*|)(\/?)>|<\/#{prefix}:([-\w:]+?)\s*>}      
     end
     
     # Parses a given string and returns an array of nodes.
@@ -47,7 +47,7 @@ module Radius
 
     def parse_attributes(text) # :nodoc:
       attr = {}
-      re = /(\w+?)\s*=\s*('|")(.*?)\2/
+      re = /([-\w]+?)\s*=\s*('|")(.*?)\2/
       while md = re.match(text)
         attr[$1] = $3
         text = md.post_match

--- a/test/parser_test.rb
+++ b/test/parser_test.rb
@@ -39,6 +39,14 @@ class RadiusParserTest < Test::Unit::TestCase
 
     assert_parse_output 'ok', '<r:some-tag>nope</r:some-tag>'
   end
+
+  def test_parse_tag_with_dashed_attributes
+    define_tag 'tag-with-dashed-attributes' do |tag|
+      "dashed: #{tag.attr['data-dashed']} regular: #{tag.attr['regular']}"
+    end
+    assert_parse_output 'dashed: dashed-value regular: value', '<r:tag-with-dashed-attributes data-dashed="dashed-value" regular="value"></r:tag-with-dashed-attributes>'
+  end
+
   
   def test_parse_individual_tags_and_parameters
     define_tag "add" do |tag|


### PR DESCRIPTION
I am using radius to render rails templates for a site that uses a lot of data-\* attributes in tags.
Attempting to specify such an attribute, e.g.

```
<r:tag data-value="43">
```

raises an exception as radius does not expect the attribute names to contain dashes.

The fix is quite simple. Tested on MRI 1.9.3 and 2.0.0.
