### PR TITLE
README: Update Travis CI badge path

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,9 @@
 language: ruby
 rvm:
-  - 1.8.7
   - 1.9.3
   - 2.0.0
   - rbx-18mode
   - rbx-19mode
-  - jruby-18mode
   - jruby-19mode
 env:
 - COVERALLS=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: ruby
 rvm:
   - 1.9.3
   - 2.0.0
-  - rbx-18mode
   - rbx-19mode
   - jruby-19mode
 env:

--- a/README.rdoc
+++ b/README.rdoc
@@ -1,6 +1,6 @@
 = Radius -- Powerful Tag-Based Templates
 
-{<img src="https://travis-ci.org/jlong/radius.png?branch=master" alt="Build Status" />}[https://travis-ci.org/jlong/radius] {<img src="https://codeclimate.com/github/jlong/radius.png" />}[https://codeclimate.com/github/jlong/radius] {<img src="https://coveralls.io/repos/jlong/radius/badge.png" alt="Coverage Status" />}[https://coveralls.io/r/jlong/radius]
+{<img src="https://travis-ci.org/jlong/radius.svg?branch=master" alt="Build Status" />}[https://travis-ci.org/jlong/radius] {<img src="https://codeclimate.com/github/jlong/radius.png" />}[https://codeclimate.com/github/jlong/radius] {<img src="https://coveralls.io/repos/jlong/radius/badge.png" alt="Coverage Status" />}[https://coveralls.io/r/jlong/radius]
 
 
 Radius is a powerful tag-based template language for Ruby inspired by the


### PR DESCRIPTION
It might just be my Safari browser, but I'm not seeing the badge render on the project overview page. 