### PR TITLE
support attribute names with dash

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ gemspec
 group :test do
   gem 'rdoc'
   gem 'rake'
+  gem 'test-unit'
   gem 'kramdown'
   gem "simplecov"
   gem 'coveralls', :require => false

--- a/lib/radius/parser/scanner.rb
+++ b/lib/radius/parser/scanner.rb
@@ -4,7 +4,7 @@ module Radius
     # The regular expression used to find (1) opening and self-enclosed tag names, (2) self-enclosing trailing slash, 
     # (3) attributes and (4) closing tag 
     def scanner_regex(prefix = nil)
-      %r{<#{prefix}:([-\w:]+?)(\s+(?:\w+\s*=\s*(?:"[^"]*?"|'[^']*?')\s*)*|)(\/?)>|<\/#{prefix}:([-\w:]+?)\s*>}
+      %r{<#{prefix}:([-\w:]+?)(\s+(?:[-\w]+\s*=\s*(?:"[^"]*?"|'[^']*?')\s*)*|)(\/?)>|<\/#{prefix}:([-\w:]+?)\s*>}
     end
     
     # Parses a given string and returns an array of nodes.
@@ -47,7 +47,7 @@ module Radius
 
     def parse_attributes(text) # :nodoc:
       attr = {}
-      re = /(\w+?)\s*=\s*('|")(.*?)\2/
+      re = /([-\w]+?)\s*=\s*('|")(.*?)\2/
       while md = re.match(text)
         attr[$1] = $3
         text = md.post_match

--- a/test/parser_test.rb
+++ b/test/parser_test.rb
@@ -52,7 +52,14 @@ class RadiusParserTest < Test::Unit::TestCase
     assert_parse_output attributes, %{<r:attr a="1" b='2'c="3"d="'" />}
     assert_parse_output attributes, %{<r:attr a="1" b='2'c="3"d="'"></r:attr>}
   end
-  
+
+  def test_parse_attribute_names_with_dash_and_underscore
+    attributes = %{{"a_b"=>"1"}}
+    assert_parse_output attributes, %{<r:attr a_b="1" />}
+    attributes = %{{"c-d"=>"1"}}
+    assert_parse_output attributes, %{<r:attr c-d="1" />}
+  end
+
   def test_parse_attributes_with_slashes_or_angle_brackets
     slash = %{{"slash"=>"/"}}
     angle = %{{"angle"=>">"}}


### PR DESCRIPTION
Radius 0.7.4 raises Radius::WrongEndTagError (wrong end tag `snippet' found for start tag `' with stack []): on 

```
  <r:snippet name="head" jquery-version="some-version">
    some content
  </r:snippet>
```

Radius 0.6.1 doesn't raise an exception.

related to #12 


My branch name is wrong (underscore was already working).