### PR TITLE
Add licensing information to gemspec.

### DIFF
--- a/radius.gemspec
+++ b/radius.gemspec
@@ -4,6 +4,7 @@ require File.join(File.dirname(__FILE__), 'lib', 'radius', 'version')
 Gem::Specification.new do |s|
   s.name = %q{radius}
   s.version = ::Radius.version
+  s.licenses = ["MIT"]
 
   s.required_rubygems_version = Gem::Requirement.new("> 1.3.1") if s.respond_to? :required_rubygems_version=
   s.authors = [%q{John W. Long (me@johnwlong.com)}, %q{David Chelimsky (dchelimsky@gmail.com)}, %q{Bryce Kerley (bkerley@brycekerley.net)}]


### PR DESCRIPTION
This should make it easier for automated tools to find out what license is used.