### PR TITLE
Fix DelegatedOpenStruct

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 = Change Log
 
 == 0.8.0
+* Ensure that the DelegatingOpenStruct is a true copy of the original [saturnflyer]
 * Avoid errors with frozen strings in Ruby 3.4+ [jeremyevans]
 * Drop support for EOL versions of Ruby
 

--- a/lib/radius/context.rb
+++ b/lib/radius/context.rb
@@ -96,7 +96,7 @@ module Radius
       def stack(name, attributes, block)
         previous = @tag_binding_stack.last
         previous_locals = previous.nil? ? globals : previous.locals
-        locals = DelegatingOpenStruct.new(previous_locals)
+        locals = previous_locals.dup
         binding = TagBinding.new(self, locals, name, attributes, block)
         @tag_binding_stack.push(binding)
         result = yield(binding)

--- a/lib/radius/utility.rb
+++ b/lib/radius/utility.rb
@@ -22,15 +22,12 @@ module Radius
     end
     
     def self.camelize(underscored_string)
-      string = ''
-      underscored_string.split('_').each { |part| string << part.capitalize }
-      string
+      underscored_string.split('_').map(&:capitalize).join
     end
 
     def self.array_to_s(c)
-      c.map do |x|
-        res = (x.is_a?(Array) ? array_to_s(x) : x.to_s)
-        +res
+      +c.map do |x|
+        x.is_a?(Array) ? array_to_s(x) : x.to_s
       end.join
     end
   end

--- a/test/context_test.rb
+++ b/test/context_test.rb
@@ -35,6 +35,14 @@ class RadiusContextTest < Minitest::Test
     assert_equal 'arg', @context.name
   end
   
+  def test_dup_preserves_delegated_values
+    @context = Radius::Context.new
+    @context.globals.object = Object.new.tap { |o| def o.special_method; "special"; end }
+    duped = @context.dup
+
+    assert_equal "special", duped.globals.special_method, "Duped context should preserve delegated object methods"
+  end
+
   def test_with
     got = @context.with do |c|
       assert_equal @context, c


### PR DESCRIPTION
A `dup`ed open struct would not maintain the reference to the `object`.