### PR TITLE
Add OrdString method to coerce objects

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,8 @@
 
 == Unreleased
 
+* Add OrdString coercion method to avoid extra allocations [saturnflyer]
+
 == 0.8.0
 * Ensure that the DelegatingOpenStruct is a true copy of the original [saturnflyer]
 * Avoid errors with frozen strings in Ruby 3.4+ [jeremyevans]

--- a/lib/radius/ord_string.rb
+++ b/lib/radius/ord_string.rb
@@ -1,4 +1,12 @@
 module Radius
+  module_function def OrdString(string_or_ord_string)
+    if string_or_ord_string.is_a?(OrdString)
+      string_or_ord_string
+    else
+      OrdString.new(string_or_ord_string)
+    end
+  end
+
   class OrdString < String
     def [](*args)
       if args.size == 1 && args.first.is_a?(Integer)

--- a/lib/radius/parser/scanner.rb
+++ b/lib/radius/parser/scanner.rb
@@ -10,7 +10,7 @@ module Radius
     # Parses a given string and returns an array of nodes.
     # The nodes consist of strings and hashes that describe a Radius tag that was found.
     def operate(prefix, data)
-      data = Radius::OrdString.new data
+      data = Radius::OrdString(data)
       @nodes = ['']
       
       re = scanner_regex(prefix)


### PR DESCRIPTION
This will avoid extra allocations in the scanner.